### PR TITLE
fix: 修复错误上报 Issue 链接无法打开

### DIFF
--- a/src/lib/supportLinks.test.ts
+++ b/src/lib/supportLinks.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildIssueReportUrl,
+  GITHUB_ISSUES_URL,
+  GITHUB_ISSUE_URL_MAX_LENGTH,
+} from './supportLinks'
+
+describe('buildIssueReportUrl', () => {
+  it('builds a prefilled issue URL against the configured issue tracker', () => {
+    const url = buildIssueReportUrl({
+      title: '[Bug] source-selector failed',
+      bodyLines: ['## Summary', 'Sample body'],
+    })
+    const parsed = new URL(url)
+
+    expect(`${parsed.origin}${parsed.pathname}`).toBe(`${GITHUB_ISSUES_URL}/new`)
+    expect(parsed.searchParams.get('title')).toBe('[Bug] source-selector failed')
+    expect(parsed.searchParams.get('body')).toBe('## Summary\nSample body')
+  })
+
+  it('truncates large issue bodies so URL stays openable', () => {
+    const url = buildIssueReportUrl({
+      title: '[Bug] huge payload',
+      bodyLines: ['x'.repeat(GITHUB_ISSUE_URL_MAX_LENGTH * 3)],
+    })
+    const parsed = new URL(url)
+    const body = parsed.searchParams.get('body') ?? ''
+
+    expect(url.length).toBeLessThanOrEqual(GITHUB_ISSUE_URL_MAX_LENGTH)
+    expect(body).toContain('[truncated: additional diagnostic details were omitted')
+  })
+
+  it('falls back to truncated title when title alone is too long', () => {
+    const url = buildIssueReportUrl({
+      title: 't'.repeat(GITHUB_ISSUE_URL_MAX_LENGTH * 2),
+    })
+    const parsed = new URL(url)
+    const title = parsed.searchParams.get('title') ?? ''
+
+    expect(url.length).toBeLessThanOrEqual(GITHUB_ISSUE_URL_MAX_LENGTH)
+    expect(title.endsWith('...')).toBe(true)
+  })
+})

--- a/src/lib/supportLinks.ts
+++ b/src/lib/supportLinks.ts
@@ -1,21 +1,96 @@
 export const GITHUB_REPO_URL = 'https://github.com/blueberrycongee/CursorLens'
-export const GITHUB_ISSUES_URL = `${GITHUB_REPO_URL}/issues`
+export const GITHUB_ISSUE_REPO_URL = 'https://github.com/siddharthvaddem/openscreen'
+export const GITHUB_ISSUES_URL = `${GITHUB_ISSUE_REPO_URL}/issues`
+export const GITHUB_ISSUE_URL_MAX_LENGTH = 7_500
 
-export function buildIssueReportUrl(input: {
-  title?: string
-  bodyLines?: string[]
-}): string {
+const BODY_TRUNCATION_NOTE =
+  '\n\n[truncated: additional diagnostic details were omitted to keep this issue URL openable]'
+const TITLE_TRUNCATION_SUFFIX = '...'
+
+function buildIssueNewUrl(title?: string, body?: string): string {
   const params = new URLSearchParams()
-  const title = input.title?.trim()
   if (title) {
     params.set('title', title)
   }
-
-  const body = (input.bodyLines ?? []).join('\n').trim()
   if (body) {
     params.set('body', body)
   }
 
   const serialized = params.toString()
   return serialized ? `${GITHUB_ISSUES_URL}/new?${serialized}` : `${GITHUB_ISSUES_URL}/new`
+}
+
+function truncateBodyToFit(title: string | undefined, body: string): string | null {
+  const bodyWithNote = (prefix: string) => `${prefix.trimEnd()}${BODY_TRUNCATION_NOTE}`
+  if (buildIssueNewUrl(title, BODY_TRUNCATION_NOTE).length > GITHUB_ISSUE_URL_MAX_LENGTH) {
+    return null
+  }
+
+  let low = 0
+  let high = body.length
+  let best: string | null = null
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2)
+    const candidate = bodyWithNote(body.slice(0, mid))
+    if (buildIssueNewUrl(title, candidate).length <= GITHUB_ISSUE_URL_MAX_LENGTH) {
+      best = candidate
+      low = mid + 1
+    } else {
+      high = mid - 1
+    }
+  }
+  return best
+}
+
+function truncateTitleToFit(title: string): string | null {
+  if (buildIssueNewUrl(title).length <= GITHUB_ISSUE_URL_MAX_LENGTH) {
+    return title
+  }
+  if (buildIssueNewUrl(TITLE_TRUNCATION_SUFFIX).length > GITHUB_ISSUE_URL_MAX_LENGTH) {
+    return null
+  }
+
+  let low = 0
+  let high = title.length
+  let best: string | null = null
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2)
+    const candidate = `${title.slice(0, mid).trimEnd()}${TITLE_TRUNCATION_SUFFIX}`
+    if (buildIssueNewUrl(candidate).length <= GITHUB_ISSUE_URL_MAX_LENGTH) {
+      best = candidate
+      low = mid + 1
+    } else {
+      high = mid - 1
+    }
+  }
+  return best
+}
+
+export function buildIssueReportUrl(input: {
+  title?: string
+  bodyLines?: string[]
+}): string {
+  const title = input.title?.trim()
+  const body = (input.bodyLines ?? []).join('\n').trim()
+
+  const fullUrl = buildIssueNewUrl(title, body)
+  if (fullUrl.length <= GITHUB_ISSUE_URL_MAX_LENGTH) {
+    return fullUrl
+  }
+
+  if (body) {
+    const truncatedBody = truncateBodyToFit(title, body)
+    if (truncatedBody) {
+      return buildIssueNewUrl(title, truncatedBody)
+    }
+  }
+
+  if (title) {
+    const truncatedTitle = truncateTitleToFit(title)
+    if (truncatedTitle) {
+      return buildIssueNewUrl(truncatedTitle)
+    }
+  }
+
+  return `${GITHUB_ISSUES_URL}/new`
 }


### PR DESCRIPTION
## Summary
- 将错误反馈 Issue 目标地址切换为可创建 issue 的仓库入口
- 为预填充 issue 链接增加长度保护，避免超长 query 导致 GitHub 414/无法打开
- 新增 `supportLinks` 单测覆盖正常拼接、超长 body 截断、超长 title 回退

## Validation
- `npm run test -- src/lib/supportLinks.test.ts`

## Root Cause
- 现有链接目标 `https://github.com/blueberrycongee/CursorLens/issues/new` 返回 404
- 且错误详情过长时 URL query 会超出 GitHub 可接受长度
