### PR TITLE
fix: route issue report links to CursorLens repository

### DIFF
--- a/src/lib/supportLinks.test.ts
+++ b/src/lib/supportLinks.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildIssueReportUrl,
+  GITHUB_REPO_URL,
   GITHUB_ISSUES_URL,
   GITHUB_ISSUE_URL_MAX_LENGTH,
 } from './supportLinks'
 
 describe('buildIssueReportUrl', () => {
+  it('targets this repository issue tracker', () => {
+    expect(GITHUB_ISSUES_URL).toBe(`${GITHUB_REPO_URL}/issues`)
+  })
+
   it('builds a prefilled issue URL against the configured issue tracker', () => {
     const url = buildIssueReportUrl({
       title: '[Bug] source-selector failed',

--- a/src/lib/supportLinks.ts
+++ b/src/lib/supportLinks.ts
@@ -1,5 +1,5 @@
 export const GITHUB_REPO_URL = 'https://github.com/blueberrycongee/CursorLens'
-export const GITHUB_ISSUE_REPO_URL = 'https://github.com/siddharthvaddem/openscreen'
+export const GITHUB_ISSUE_REPO_URL = GITHUB_REPO_URL
 export const GITHUB_ISSUES_URL = `${GITHUB_ISSUE_REPO_URL}/issues`
 export const GITHUB_ISSUE_URL_MAX_LENGTH = 7_500
 


### PR DESCRIPTION
## Summary
- 将错误上报 issue 的目标仓库从上游改回 `blueberrycongee/CursorLens`
- 保留现有 URL 长度保护逻辑，避免超长链接打不开
- 增加单测断言，确保 issue 链接始终指向当前仓库

## Validation
- `npm run test -- src/lib/supportLinks.test.ts`

## Notes
- 仓库 `Issues` 已启用，`/issues/new` 入口可用
