### PR TITLE
fix(permissions): add macOS entitlements and signing config for permission visibility

### DIFF
--- a/build/entitlements.mac.inherit.plist
+++ b/build/entitlements.mac.inherit.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+  <key>com.apple.security.device.camera</key>
+  <true/>
+</dict>
+</plist>

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+  <key>com.apple.security.device.camera</key>
+  <true/>
+</dict>
+</plist>

--- a/build/entitlements.native-helper-av.plist
+++ b/build/entitlements.native-helper-av.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+  <key>com.apple.security.device.camera</key>
+  <true/>
+</dict>
+</plist>

--- a/build/entitlements.native-helper.plist
+++ b/build/entitlements.native-helper.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -44,7 +44,12 @@
   ],
 
   "mac": {
+    "hardenedRuntime": true,
+    "gatekeeperAssess": false,
+    "entitlements": "build/entitlements.mac.plist",
+    "entitlementsInherit": "build/entitlements.mac.inherit.plist",
     "extendInfo": {
+      "NSScreenCaptureUsageDescription": "CursorLens needs screen recording access to capture your screen.",
       "NSCameraUsageDescription": "CursorLens needs camera access to render camera overlays while recording.",
       "NSMicrophoneUsageDescription": "CursorLens needs microphone access to record your voice during screen capture.",
       "NSSpeechRecognitionUsageDescription": "CursorLens needs speech recognition access to generate subtitles from recordings."


### PR DESCRIPTION
## Problem

Users cannot find CursorLens in macOS System Settings → Privacy & Security permission lists (Screen Recording, Camera, Microphone, etc.), making it impossible to grant permissions via the system toggle switches.

PR #8 correctly added code to trigger permission request dialogs, but the app still doesn't appear in the system settings because the build was missing entitlements and hardened runtime configuration.

## Root Cause

1. **No entitlements files** — macOS requires apps to declare entitlements for the system to register them in privacy permission lists
2. **No hardened runtime** — `electron-builder.json5` was missing `hardenedRuntime: true`
3. **Missing `NSScreenCaptureUsageDescription`** — the screen recording usage description was not declared in Info.plist
4. **Native Swift helpers were unsigned** — `sck-recorder` and other helpers were compiled without codesign or entitlements

## Changes

- **`build/entitlements.mac.plist`** — Main app entitlements (camera, microphone, JIT, unsigned memory, library validation)
- **`build/entitlements.mac.inherit.plist`** — Inherited entitlements for child processes
- **`build/entitlements.native-helper.plist`** — Entitlements for Swift helper binaries
- **`electron-builder.json5`** — Enable `hardenedRuntime`, reference entitlements files, add `NSScreenCaptureUsageDescription`
- **`scripts/build-native-macos-helper.mjs`** — Ad-hoc codesign each Swift helper with entitlements after compilation

## Notes

- This uses ad-hoc signing (`-` identity), no Apple Developer account required
- Users will still need to right-click → Open on first launch (no notarization)
- The permission request flow from PR #8 should now work correctly with these entitlements in place

Closes #5